### PR TITLE
fix: 修复Terminal切换导致的显示错误

### DIFF
--- a/packages/libro-terminal/src/view.tsx
+++ b/packages/libro-terminal/src/view.tsx
@@ -182,6 +182,7 @@ export class LibroTerminalView extends BaseStatefulView {
     this.toDispose.push(
       this.term.onResize((data) => {
         this.onSizeChangedEmitter.fire(data);
+        this.setSessionSize();
       }),
     );
 
@@ -455,13 +456,22 @@ export class LibroTerminalView extends BaseStatefulView {
     if (!this.isVisible) {
       return;
     }
+    if (this.container?.current) {
+      if (this.container.current.offsetHeight === 0) {
+        return;
+      }
+      if (this.container.current.offsetWidth === 0) {
+        return;
+      }
+    }
+
+    // 触发term的resize 事件
     this.processResize();
   };
 
   protected processResize = () => {
     this.open();
     this.resizeTerminal();
-    this.setSessionSize();
   };
 
   protected open = (): void => {


### PR DESCRIPTION
## 背景
多个Terminal切换的时候会导致显示错误，原因是切换导致View resize触发，获取的高度或宽度为0导致的显示异常
## Action
- 高度或宽度为0的时候不触发服务端resize
## 其他
测试页面修改为Tab模式，支持多个Terminal切换
![image](https://github.com/difizen/libro/assets/16317354/ecc54c69-6572-4908-ac47-67c4da88161f)
