### PR TITLE
fix: get correct url when create notebook file

### DIFF
--- a/packages/libro-kernel/src/contents/contents-drive.ts
+++ b/packages/libro-kernel/src/contents/contents-drive.ts
@@ -168,7 +168,9 @@ export class Drive implements IContentsDrive {
    */
   async newUntitled(options: IContentsCreateOptions = {}): Promise<IContentsModel> {
     let body = '{}';
+    const url = this.getUrl(options.baseUrl, options.path ?? '');
     const settings = this._getSettings(options.baseUrl);
+
     if (options) {
       if (options.ext) {
         options.ext = normalizeExtension(options.ext);
@@ -179,7 +181,6 @@ export class Drive implements IContentsDrive {
       body = JSON.stringify(options);
     }
 
-    const url = this.getUrl(options.baseUrl, options.path ?? '');
     const init = {
       method: 'POST',
       body,


### PR DESCRIPTION
### 问题
如果 options 传入了 baseUrl，按照现有逻辑，会将 baseUrl 删除，导致实际 url 获取错误。