### PR TITLE
fix: libro kernel shutdown

### DIFF
--- a/packages/libro-jupyter/src/cell/jupyter-code-cell-view.tsx
+++ b/packages/libro-jupyter/src/cell/jupyter-code-cell-view.tsx
@@ -210,8 +210,7 @@ export class JupyterCodeCellView extends LibroCodeCellView {
       }
       (cellModel.metadata.execution as any)['libro_execution_msg_id'] =
         future.msg.header.msg_id;
-      // 触发保存
-      this.parent.model.saveNotebookContent();
+      cellModel.metadata = { ...cellModel.metadata };
 
       // Handle iopub messages
       future.onIOPub = (msg: any) => {
@@ -222,8 +221,7 @@ export class JupyterCodeCellView extends LibroCodeCellView {
             to_execute: new Date().toISOString(),
             libro_execution_msg_id: future.msg.header.msg_id,
           } as ExecutionMeta;
-          // 触发保存
-          this.parent.model.saveNotebookContent();
+          cellModel.metadata = { ...cellModel.metadata };
           cellModel.kernelExecuting = true;
           startTimeStr = msg.header.date as string;
           const meta = cellModel.metadata.execution as ExecutionMeta;


### PR DESCRIPTION
### Description

Please include a summary of the changes and the motivation behind them. Also, include any relevant context or links to related issues.

### Type of Change

Please mark the type of change:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

### Related Issues

Please list any issues related to this pull request (e.g., `Fixes #123`, `Closes #456`).

### Testing

Please describe the tests that were performed to verify your changes. Include details about the testing framework, if applicable.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Checklist

- [ ] My code follows the project’s coding style.
- [ ] I have updated the documentation as necessary.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] My changes require a change to the documentation.

### Additional Notes

1. run 方法被调用时，前端立即发起了 requestExecute 。
2. 紧接着，调用了 saveNotebookContent() ，这会向 Jupyter Server 发送一个 PUT /api/contents/... 请求。
3. Jupyter Server 收到这个 PUT 请求后，会执行保存操作。在某些 Jupyter Server 的配置或版本中，如果在 Kernel 正在繁忙（Busy）或刚刚接收到执行请求时频繁触发保存，可能会导致 文件系统锁冲突 或者 Kernel 进程状态异常 。导致 Server 认为文件已变更并试图重启 Kernel（Auto-restart），或者因为并发操作导致了 Server 内部错误进而杀死了 Kernel。

移除在 run 方法的同步路径中直接调用 saveNotebookContent 。
