### PR TITLE
fix: remove saveNotebookContent in JupyterCodeCellView

### DIFF
--- a/packages/libro-jupyter/src/cell/jupyter-code-cell-view.tsx
+++ b/packages/libro-jupyter/src/cell/jupyter-code-cell-view.tsx
@@ -67,8 +67,7 @@ export class JupyterCodeCellView extends LibroCodeCellView {
       if (msgId) {
         if (kernelConnection.status === 'idle') {
           delete execution['libro_execution_msg_id'];
-          // 触发保存
-          this.parent.model.saveNotebookContent();
+          this.model.metadata = { ...this.model.metadata };
           this.model.kernelExecuting = false;
         } else {
           this.model.kernelExecuting = true;
@@ -82,8 +81,7 @@ export class JupyterCodeCellView extends LibroCodeCellView {
                 ) {
                   this.model.kernelExecuting = false;
                   delete execution['libro_execution_msg_id'];
-                  // 触发保存
-                  this.parent.model.saveNotebookContent();
+                  this.model.metadata = { ...this.model.metadata };
                   disposable.dispose();
                 }
               }
@@ -95,8 +93,7 @@ export class JupyterCodeCellView extends LibroCodeCellView {
               if (status === 'idle') {
                 this.model.kernelExecuting = false;
                 delete execution['libro_execution_msg_id'];
-                // 触发保存
-                this.parent.model.saveNotebookContent();
+                this.model.metadata = { ...this.model.metadata };
                 disposable.dispose();
                 statusDisposable.dispose();
               }


### PR DESCRIPTION
…IGTERM

### Description

Please include a summary of the changes and the motivation behind them. Also, include any relevant context or links to related issues.

### Type of Change

Please mark the type of change:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

### Related Issues

Please list any issues related to this pull request (e.g., `Fixes #123`, `Closes #456`).

### Testing

Please describe the tests that were performed to verify your changes. Include details about the testing framework, if applicable.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Checklist

- [ ] My code follows the project’s coding style.
- [ ] I have updated the documentation as necessary.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] My changes require a change to the documentation.

### Additional Notes

页面刷新时，前端与 Kernel 建立 WebSocket 连接的过程非常繁忙。此时如果并发地向 Server 发送 PUT 请求保存文件，容易与 Server 内部的状态同步（或文件锁）发生冲突。避免在 jupyter-code-cell-view 中调用 saveNotebookContent。
